### PR TITLE
Don't require setting the owner

### DIFF
--- a/src/GprTool/Program.cs
+++ b/src/GprTool/Program.cs
@@ -105,8 +105,8 @@ namespace GprTool
         [Argument(0, Description = "Path to the package file")]
         public string PackageFile { get; set; }
 
-        [Option("--owner", Description = "The name of the user/org to publish under")]
-        public string Owner { get; } = "GRPTOOL_DEFAULT_OWNER";
+        [Option("--owner", Description = "The owner if repository URL wasn't specified in nupkg/nuspec")]
+        public string Owner { get; } = "GPR-TOOL-DEFAULT-OWNER";
     }
 
     /// <summary>


### PR DESCRIPTION
If `<RespositoryUrl>` hasn't been specified in project file (`<repository url=` in `.nuspec`), the target repository owner will be taken from the path in the REST endpoint (e.g. https://nuget.pkg.github.com/{Owner}/). The repository name will be taken from the project's `<PackageId>` (which defaults to the project's name), which maps to `<id>` in the `.nuspec` file.

The `--owner` option is a way to specify the owner when repository URL isn't set and the package ID maps to the name of a repository.

This PR gives the `--owner` a default of `GPR-TOOL-DEFAULT-OWNER`. This allows the `PUT` to succeed, but the value itself will usually be ignored.

Fixes #10