### PR TITLE
Build with .NET Core

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -18,4 +18,4 @@ jobs:
     - name: Build with dotnet
       run: dotnet pack --configuration Release
     - name: Run the tool
-      run: dotnet exec .\src\GprTool\bin\Release\netcoreapp3.0\gpr.dll
+      run: dotnet exec ./src/GprTool/bin/Release/netcoreapp3.0/gpr.dll


### PR DESCRIPTION
- We need to use dotnet version `3.1.100` (`3.1` isn't a thing)
- Use `NerdBank.GitVersioning` action
- Run the tool