### PR TITLE
User setup-dotnet to configure NuGet

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -12,11 +12,13 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.100
+        source-url: https://nuget.pkg.github.com/jcansdale/index.json
+        config-file: nuget.config
+      env:
+        NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
     - name: Install GPR tool
       run: dotnet tool install gpr --tool-path ~/tools
     - uses: actions/checkout@v1
-    - name: Set API key for GitHub Package Registry
-      run: ~/tools/gpr setApiKey ${{ secrets.GITHUB_TOKEN }}  --config-file nuget.config
     - uses: aarnott/nbgv@v0.3
       id: nbgv
     - name: Build with dotnet

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -18,6 +18,8 @@ jobs:
         NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
     - name: Install GPR tool
       run: dotnet tool install gpr --tool-path ~/tools
+    - name: Show config file
+      run: ~/tools/gpr setApiKey --config-file /home/runner/work/nuget.config
     - uses: actions/checkout@v1
     - uses: aarnott/nbgv@v0.3
       id: nbgv


### PR DESCRIPTION
I've tried adding this:

```
      uses: actions/setup-dotnet@v1
      with:
        dotnet-version: 3.1.100
        source-url: https://nuget.pkg.github.com/jcansdale/index.json
        config-file: nuget.config
      env:
        NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
```

This is currently generating the following at: `/home/runner/work/nuget.config`.

```xml
<?xml version="1.0"?>
<configuration>
  <config>
    <add key="defaultPushSource" value="https://nuget.pkg.github.com/jcansdale/index.json"/>
  </config>
  <packageSources>
    <add key="Source" value="https://nuget.pkg.github.com/jcansdale/index.json"/>
  </packageSources>
  <packageSourceCredentials>
    <Source>
      <add key="Username" value="jcansdale"/>
      <add key="ClearTextPassword" value="***"/>
    </Source>
  </packageSourceCredentials>
</configuration>
```

What we need is for source to be `github` and for the `packageSources` element to not be generated. Not sure how to do this. 😕 
