### PR TITLE
Refactor to use Octokit.GraphQL.NET

### DIFF
--- a/src/GprTool/GprTool.csproj
+++ b/src/GprTool/GprTool.csproj
@@ -19,6 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.4.1" />
+    <PackageReference Include="Octokit.GraphQL" Version="0.1.4-preview-package-deletes" />
     <PackageReference Include="RestSharp" Version="106.10.1" />
   </ItemGroup>
   

--- a/src/GprTool/GprTool.csproj
+++ b/src/GprTool/GprTool.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.4.1" />
-    <PackageReference Include="Octokit.GraphQL" Version="0.1.4-preview-package-deletes" />
+    <PackageReference Include="Octokit.GraphQL" Version="0.1.4-packages-preview" />
     <PackageReference Include="RestSharp" Version="106.10.1" />
   </ItemGroup>
   

--- a/src/GprTool/Program.cs
+++ b/src/GprTool/Program.cs
@@ -44,15 +44,14 @@ namespace GprTool
 
             var query = new Query()
                 .Viewer
-                .RegistryPackages(first: 10)
+                .Packages(first: 100)
                 .Nodes
                 .Select(p => new
                 {
                     RepositoryUrl = p.Repository != null ? p.Repository.Url : null,
                     p.Name,
-                    p.PackageType,
-                    p.NameWithOwner,
-                    Versions = p.Versions(100, null, null, null).Nodes.Select(v => v.Version).ToList()
+//                    p.PackageType, what happened to this?
+                    Versions = p.Versions(100, null, null, null, null).Nodes.Select(v => v.Version).ToList()
                 })
                 .Compile();
 
@@ -64,7 +63,7 @@ namespace GprTool
                 Console.WriteLine(group.Key);
                 foreach(var package in group)
                 {
-                    Console.WriteLine($"    {package.Name} ({package.PackageType}) [{string.Join(", ", package.Versions)}]");
+                    Console.WriteLine($"    {package.Name} [{string.Join(", ", package.Versions)}]");
                 }
             }
         }

--- a/src/GprTool/Program.cs
+++ b/src/GprTool/Program.cs
@@ -50,6 +50,7 @@ namespace GprTool
                 {
                     RepositoryUrl = p.Repository != null ? p.Repository.Url : null,
                     p.Name,
+                    p.Statistics.DownloadsTotalCount,
 //                    p.PackageType, what happened to this?
                     Versions = p.Versions(100, null, null, null, null).Nodes.Select(v => v.Version).ToList()
                 })
@@ -63,7 +64,7 @@ namespace GprTool
                 Console.WriteLine(group.Key);
                 foreach(var package in group)
                 {
-                    Console.WriteLine($"    {package.Name} [{string.Join(", ", package.Versions)}]");
+                    Console.WriteLine($"    {package.Name} [{string.Join(", ", package.Versions)}] ({package.DownloadsTotalCount} downloads)");
                 }
             }
         }


### PR DESCRIPTION
Use Octokit.GraphQL.NET instead of RestSharp and hand crafted GraphQL / Json parsing!

- Use `Octokit.GraphQL.NET 0.1.4-packages-preview`
- Convert `list` command to use this