### PR TITLE
Show the package type

### DIFF
--- a/src/GprTool/GprTool.csproj
+++ b/src/GprTool/GprTool.csproj
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.4.1" />
-    <PackageReference Include="Octokit.GraphQL" Version="0.1.4-packages-preview" />
+    <PackageReference Include="Octokit.GraphQL" Version="0.1.4-packages-preview2" />
     <PackageReference Include="RestSharp" Version="106.10.1" />
   </ItemGroup>
   

--- a/src/GprTool/Program.cs
+++ b/src/GprTool/Program.cs
@@ -74,7 +74,7 @@ namespace GprTool
                 Console.WriteLine(group.Key);
                 foreach (var package in group)
                 {
-                    Console.WriteLine($"    {package.Name} [{string.Join(", ", package.Versions)}] ({package.DownloadsTotalCount} downloads)");
+                    Console.WriteLine($"    {package.Name} ({package.PackageType}) [{string.Join(", ", package.Versions)}] ({package.DownloadsTotalCount} downloads)");
                 }
             }
         }
@@ -87,6 +87,7 @@ namespace GprTool
                 {
                     RepositoryUrl = p.Repository != null ? p.Repository.Url : "[PRIVATE REPOSITORIES]",
                     Name = p.Name,
+                    PackageType = p.PackageType,
                     DownloadsTotalCount = p.Statistics.DownloadsTotalCount,
                     Versions = p.Versions(100, null, null, null, null).Nodes.Select(v => v.Version).ToList()
                 })
@@ -110,6 +111,7 @@ namespace GprTool
         {
             internal string RepositoryUrl;
             internal string Name;
+            internal PackageType PackageType;
             internal int DownloadsTotalCount;
             internal IList<string> Versions;
         }


### PR DESCRIPTION
- Include the package type
- Update the GraphQL schema


E.g.

```
https://github.com/jcansdale/GitHubPackagesExample
    OctocatApp (Nuget) [] (0 downloads)
https://github.com/jcansdale/gpr
    gpr (Docker) [0.1.95-g5167f5fe04, 0.1.94-ge867c8eeab, 0.1.97-g0a1e4284e1, latest, 0.1.96-gf99a0903fc, 0.1.95-ged4d8a9f99, 0.1.94, 0.1.93, 0.1.92-g2f1a52d7e4, alpha, docker-base-layer] (4 downloads)
    gpr (Nuget) [0.1.96-g2655089c02, 0.1.95-g5167f5fe04, 0.1.94-ge867c8eeab, 0.1.97-g0a1e4284e1, 0.1.96-gf99a0903fc, 0.1.95-ged4d8a9f99, 0.1.94, 0.1.93, 0.1.92-g2f1a52d7e4, 0.1.91-g4712918564, 0.1.90-g9b8168c586, 0.1.89-g78f280cb9c, 0.1.81, 0.1.80, 0.1.79, 0.1.78, 0.1.77, 0.1.82, 0.1.88-g6e4562a1a2, 0.1.81-gddcdb4b240, 0.1.80-gf082a28261, 0.1.78-g3a852e0245, 0.1.76, 0.1.74, 0.1.73-gf14999c3fc, 0.1.72-g823f26c261, 0.1.71, 0.1.70-gdb6594055d, 0.1.68-g58de02ba7b, 0.1.67, 0.1.66, 0.1.65, 0.1.64, 0.1.63, 0.1.62, 0.1.53, 0.1.52, 0.1.51, 0.1.50, 0.1.49, 0.1.24-gbcbef0aaa4, 0.1.23-gf6752bcbb9, 0.1.22-g8e7b699a35, 0.1.16, 0.1.13-beta, 0.1.10-beta, 0.1.8-beta-gce0e7f72ce, 0.1.0-beta, 0.1.0-alpha] (6 downloads)
https://github.com/jcansdale/octokit.graphql.net
    Octokit.GraphQL (Nuget) [0.1.4-packages-preview2, 0.1.4-packages-preview, 0.1.4-preview-package-deletes] (163 downloads)
    Octokit.GraphQL.Core (Nuget) [0.1.4-packages-preview2, 0.1.4-packages-preview, 0.1.4-preview-package-deletes] (163 downloads)
    Octokit.GraphQL.Core.Generation (Nuget) [0.1.4-preview-package-deletes] (0 downloads)
https://github.com/jcansdale/PackageRegistryTest
    console-app (Nuget) [1.0.4] (0 downloads)
    PublishPackage (Nuget) [1.0.3, 1.0.2, 1.0.1, 1.0.0] (14 downloads)
    TestPack (Nuget) [1.0.0] (0 downloads)
    workspace (Nuget) [1.0.0] (0 downloads)
```
