### PR TITLE
Allow docker image to use default read:packages token

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,7 +8,7 @@ jobs:
     - uses: aarnott/nbgv@v0.3
       id: nbgv
     - name: Build docker image
-      run: docker build . -t docker.pkg.github.com/jcansdale/gpr/gpr:${{ steps.nbgv.outputs.SemVer2 }}
+      run: docker build . -t docker.pkg.github.com/jcansdale/gpr/gpr:${{ steps.nbgv.outputs.SemVer2 }} --build-arg READ_PACKAGES_TOKEN=${{ secrets.READ_PACKAGES_TOKEN }}
     - name: Publish docker image
       run: |
         docker login -u jcansdale -p ${{ secrets.GITHUB_TOKEN }} docker.pkg.github.com

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,6 @@ FROM mcr.microsoft.com/dotnet/core/runtime:3.1 AS production
 LABEL maintainer="jcansdale@gmail.com"
 WORKDIR /tool
 COPY --from=build /publish .
+ARG READ_PACKAGES_TOKEN
+ENV READ_PACKAGES_TOKEN=$READ_PACKAGES_TOKEN
 ENTRYPOINT [ "./gpr" ]

--- a/src/GprTool/Program.cs
+++ b/src/GprTool/Program.cs
@@ -279,8 +279,15 @@ namespace GprTool
                 return configToken;
             }
 
+            if (FindReadPackagesToken() is string readToken)
+            {
+                return readToken;
+            }
+
             throw new ApplicationException("Couldn't find personal access token");
         }
+
+        static string FindReadPackagesToken() => Environment.GetEnvironmentVariable("READ_PACKAGES_TOKEN");
 
         protected void Warning(string line) => Console.WriteLine(line);
 

--- a/src/GprTool/Program.cs
+++ b/src/GprTool/Program.cs
@@ -287,7 +287,8 @@ namespace GprTool
             throw new ApplicationException("Couldn't find personal access token");
         }
 
-        static string FindReadPackagesToken() => Environment.GetEnvironmentVariable("READ_PACKAGES_TOKEN");
+        static string FindReadPackagesToken() =>
+            (Environment.GetEnvironmentVariable("READ_PACKAGES_TOKEN") is string token && token != string.Empty) ? token : null;
 
         protected void Warning(string line) => Console.WriteLine(line);
 


### PR DESCRIPTION
Still needs refinement, but it's already useful like this.