### PR TITLE
Add support for cleaning up orphaned docker layers

### DIFF
--- a/src/GprTool/Program.cs
+++ b/src/GprTool/Program.cs
@@ -161,6 +161,31 @@ namespace GprTool
                 Console.WriteLine("Complete");
                 return;
             }
+
+            foreach(var package in packages)
+            {
+                Console.WriteLine(package.Name);
+                foreach(var version in package.Versions)
+                {
+                    if (Force)
+                    {
+                        Console.WriteLine($"  Deleting '{version.Version}'");
+
+                        var versionId = version.Id;
+                        await DeletePackageVersion(connection, versionId);
+                    }
+                    else
+                    {
+                        Console.WriteLine($"  {version.Version}");
+                    }
+                }
+            }
+
+            if (!Force)
+            {
+                Console.WriteLine();
+                Console.WriteLine($"To delete these package versions, use the --force option.");
+            }
         }
 
         async Task<bool> DeletePackageVersion(IConnection connection, ID versionId)
@@ -184,6 +209,9 @@ namespace GprTool
 
         [Option("--docker-clean-up", Description = "Clean up orphaned docker layers")]
         protected bool DockerCleanUp { get; set; }
+
+        [Option("--force", Description = "Delete all package versions")]
+        protected bool Force { get; set; }
     }
 
     [Command(Description = "List packages for user or org (viewer if not specified)")]


### PR DESCRIPTION
This PR adds package versions delete functionality. `PATH` can be a user, organization or repository.

The following command will list all package versions targeted for deletion:

```
gpr delete PATH -k TOKEN
```

The following command can be used to delete all package versions:

```
gpr delete PATH --force -k TOKEN
```

The following command can be used to clean-up orphaned `docker-base-layer` tags:

```
gpr delete PATH --docker-clean-up -k TOKEN
```