### PR TITLE
Add xmlEncode command for XML encodding tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ Options:
   -k|--api-key  The access token to use
 
 Commands:
+  delete        Delete package versions
   details       View package details
+  files         List files for a package
   list          List packages for user or org (viewer if not specified)
   push          Publish a package
   setApiKey     Set GitHub API key/personal access token
-
-Run 'gpr [command] --help' for more information about a command.
+  xmlEncode     XML encode token to prevent it fron being automatically deleted
 ```


### PR DESCRIPTION
The command will output something like this:

```
> gpr xmlencode TOKEN
This XML encoded token can be included in a public repository without being
automatically deleted by GitHub:

&#102;&#111;&#111;&#98;&#97;&#114;&#98;&#97;&#122;

For example, the following might be included in `nuget.config`:
<packageSourceCredentials>
  <github>
    <add key="Username" value="PublicToken" />
    <add key="ClearTextPassword" value="&#102;&#111;&#111;&#98;&#97;&#114;&#98;&#97;&#122;" />
  </github>
</packageSourceCredentials>

Or in a Maven `settings.xml` file:
<servers>
  <server>
    <id>github</id>
    <username>PublicToken</username>
    <password>&#102;&#111;&#111;&#98;&#97;&#114;&#98;&#97;&#122;</password>
  </server>
</servers>
```
