### PR TITLE
Show storage used when listing files

### DIFF
--- a/src/GprTool/Program.cs
+++ b/src/GprTool/Program.cs
@@ -80,11 +80,20 @@ namespace GprTool
 
             var packages = await connection.Run(query);
 
+            var totalStorage = 0;
             foreach(var package in packages)
             {
                 Console.WriteLine($"{package.Name} ({package.DownloadsTotalCount} downloads)");
                 foreach (var version in package.Versions)
                 {
+                    foreach(var file in version.Files)
+                    {
+                        if(file.Size != null)
+                        {
+                            totalStorage += (int)file.Size;
+                        }
+                    }
+
                     if(version.Files.Count == 1)
                     {
                         var file = version.Files[0];
@@ -102,6 +111,8 @@ namespace GprTool
                     }
                 }
             }
+
+            Console.WriteLine($"Storage used {totalStorage/(1024*1024)} MB");
         }
 
         [Argument(0, Description = "Path to packages the form `owner`, `owner/repo` or `owner/repo/package`")]


### PR DESCRIPTION
## Show storage used when listing files

For example:


```
> gpr files jcansdale -k TOKEN

Octokit.GraphQL (242 downloads)
  Octokit.GraphQL.0.1.4-packages-preview2.nupkg (16/02/2020, 79 downloads, 358889 bytes)
  Octokit.GraphQL.0.1.4-packages-preview.nupkg (04/02/2020, 160 downloads, 358409 bytes)
  Octokit.GraphQL.0.1.4-preview-package-deletes.nupkg (04/02/2020, 3 downloads, 353334 bytes)
Octokit.GraphQL.Core (242 downloads)
  Octokit.GraphQL.Core.0.1.4-packages-preview2.nupkg (16/02/2020, 79 downloads, 46235 bytes)
  Octokit.GraphQL.Core.0.1.4-packages-preview.nupkg (04/02/2020, 160 downloads, 46228 bytes)
  Octokit.GraphQL.Core.0.1.4-preview-package-deletes.nupkg (04/02/2020, 3 downloads, 46227 bytes)
Octokit.GraphQL.Core.Generation (0 downloads)
  Octokit.GraphQL.Core.Generation.0.1.4-preview-package-deletes.nupkg (04/02/2020, 0 downloads, 16066 bytes)
Storage used 282 MB
```


