### PR TITLE
Use long to count storage used (in bytes)

### DIFF
--- a/src/GprTool/Program.cs
+++ b/src/GprTool/Program.cs
@@ -80,7 +80,7 @@ namespace GprTool
 
             var packages = await connection.Run(query);
 
-            var totalStorage = 0;
+            long totalStorage = 0;
             foreach(var package in packages)
             {
                 Console.WriteLine($"{package.Name} ({package.DownloadsTotalCount} downloads)");


### PR DESCRIPTION
When using an `int`, total storage could overflow! 😊 

```
Storage used -1765 MB
```

Using a `long` fixes this.