### PR TITLE
Workaround for Metadata.Repository.Url being null

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,19 +5,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+
+    - name: Setup dotnet using global.json
+      uses: actions/setup-dotnet@v1.5.0
+
     - uses: aarnott/nbgv@v0.3
       id: nbgv
+
     - name: Build docker image
       run: docker build . -t docker.pkg.github.com/jcansdale/gpr/gpr:${{ steps.nbgv.outputs.SemVer2 }} --build-arg READ_PACKAGES_TOKEN=${{ secrets.READ_PACKAGES_TOKEN }}
+
     - name: Publish docker image
       run: |
         docker login -u jcansdale -p ${{ secrets.GITHUB_TOKEN }} docker.pkg.github.com
         docker push docker.pkg.github.com/jcansdale/gpr/gpr:${{ steps.nbgv.outputs.SemVer2 }}
+
     - name: Publish latest from master
       if: github.ref == 'refs/heads/master'
       run: |
         docker tag docker.pkg.github.com/jcansdale/gpr/gpr:${{ steps.nbgv.outputs.SemVer2 }} docker.pkg.github.com/jcansdale/gpr/gpr:latest
         docker push docker.pkg.github.com/jcansdale/gpr/gpr:latest
+
     - name: Publish to DockerHub
       if: github.ref == 'refs/heads/master'
       run: |

--- a/src/GprTool/NuGetUtilities.cs
+++ b/src/GprTool/NuGetUtilities.cs
@@ -73,8 +73,7 @@ namespace GprTool
         public static bool BuildOwnerAndRepositoryFromUrlFromNupkg(PackageFile packageFile)
         {
             var manifest = ReadNupkgManifest(packageFile.FilenameAbsolutePath);
-            
-            return BuildOwnerAndRepositoryFromUrl(packageFile, manifest.Metadata.Repository?.Url);
+            return BuildOwnerAndRepositoryFromUrl(packageFile, FindRepositoryUrl(manifest));
         }
 
         public static PackageFile BuildPackageFile(string filename, string repositoryUrl)
@@ -108,7 +107,16 @@ namespace GprTool
                 return true;
             }
             
-            return !string.Equals(packageFile.RepositoryUrl, manifest.Metadata.Repository?.Url, StringComparison.OrdinalIgnoreCase);
+            return !string.Equals(packageFile.RepositoryUrl, FindRepositoryUrl(manifest), StringComparison.OrdinalIgnoreCase);
+        }
+
+        static string FindRepositoryUrl(Manifest manifest)
+        {
+            // Metadata.Repository.Url appears to return null if <repository type=... /> hasn't been set.
+            // This happens when a project is built with `dotnet pack` and the RepositoryUrl property.
+            // We need to use Metadata.ProjectUrl instead!
+            
+            return manifest?.Metadata?.ProjectUrl?.ToString();
         }
 
         public static void RewriteNupkg(PackageFile packageFile, NuGetVersion nuGetVersion = null)

--- a/test/GprTool.Tests/NuGetUtilitiesTests.cs
+++ b/test/GprTool.Tests/NuGetUtilitiesTests.cs
@@ -182,20 +182,25 @@ namespace GprTool.Tests
                 Assert.That(packageFile.RepositoryUrl, Is.EqualTo(expectedGithubRepositoryUrl));
             }
 
-            [TestCase("http://github.com/jcansdale/gpr", "jcansdale", "gpr", "https://github.com/jcansdale/gpr")]
-            [TestCase("https://github.com/jcansdale/gpr", "jcansdale", "gpr", "https://github.com/jcansdale/gpr")]
-            [TestCase("https://github.com/jcansdale\\gpr", "jcansdale", "gpr", "https://github.com/jcansdale/gpr")]
-            [TestCase("https://github.com/jcansdale///////gpr", "jcansdale", "gpr", "https://github.com/jcansdale/gpr")]
-            [TestCase("  https://github.com/jcansdale/gpr ", "jcansdale", "gpr", "https://github.com/jcansdale/gpr", Description = "Whitespace")]
-            public void BuildOwnerAndRepositoryFromUrlFromNupkg(string repositoryUrl, string expectedOwner, string expectedRepositoryName, string expectedGithubRepositoryUrl)
+            [TestCase("http://github.com/jcansdale/gpr", "git", "jcansdale", "gpr", "https://github.com/jcansdale/gpr")]
+            [TestCase("https://github.com/jcansdale/gpr", "git", "jcansdale", "gpr", "https://github.com/jcansdale/gpr")]
+            [TestCase("https://github.com/jcansdale\\gpr", "git", "jcansdale", "gpr", "https://github.com/jcansdale/gpr")]
+            [TestCase("https://github.com/jcansdale///////gpr", "git", "jcansdale", "gpr", "https://github.com/jcansdale/gpr")]
+            [TestCase("  https://github.com/jcansdale/gpr ", "git", "jcansdale", "gpr", "https://github.com/jcansdale/gpr", Description = "Whitespace")]
+            [TestCase("http://github.com/jcansdale/gpr", null, "jcansdale", "gpr", "https://github.com/jcansdale/gpr")]
+            public void BuildOwnerAndRepositoryFromUrlFromNupkg(string repositoryUrl, string repositoryType, string expectedOwner, string expectedRepositoryName, string expectedGithubRepositoryUrl)
             {
                 using var packageBuilderContext = new PackageBuilderContext(TmpDirectoryPath, new NuspecContext(manifest =>
                 {
-                    manifest.Metadata.Repository = new RepositoryMetadata
-                    {                        
-                        Url = repositoryUrl,
-                        Type = "git"
-                    };
+                    if (repositoryUrl is { } && repositoryType is { })
+                    {
+                        // Only create Repository when both Url and Type are specified 
+                        manifest.Metadata.Repository = new RepositoryMetadata
+                        {
+                            Url = repositoryUrl,
+                            Type = repositoryType
+                        };
+                    }
 
                     manifest.Metadata.SetProjectUrl(repositoryUrl);
                 }));

--- a/test/GprTool.Tests/NuGetUtilitiesTests.cs
+++ b/test/GprTool.Tests/NuGetUtilitiesTests.cs
@@ -182,9 +182,6 @@ namespace GprTool.Tests
                 Assert.That(packageFile.RepositoryUrl, Is.EqualTo(expectedGithubRepositoryUrl));
             }
 
-            [TestCase("jcansdale/gpr", "jcansdale", "gpr", "https://github.com/jcansdale/gpr")]
-            [TestCase("jcansdale//gpr", "jcansdale", "gpr", "https://github.com/jcansdale/gpr")]
-            [TestCase("/jcansdale/gpr", "jcansdale", "gpr", "https://github.com/jcansdale/gpr")]
             [TestCase("http://github.com/jcansdale/gpr", "jcansdale", "gpr", "https://github.com/jcansdale/gpr")]
             [TestCase("https://github.com/jcansdale/gpr", "jcansdale", "gpr", "https://github.com/jcansdale/gpr")]
             [TestCase("https://github.com/jcansdale\\gpr", "jcansdale", "gpr", "https://github.com/jcansdale/gpr")]
@@ -195,10 +192,12 @@ namespace GprTool.Tests
                 using var packageBuilderContext = new PackageBuilderContext(TmpDirectoryPath, new NuspecContext(manifest =>
                 {
                     manifest.Metadata.Repository = new RepositoryMetadata
-                    {
+                    {                        
                         Url = repositoryUrl,
                         Type = "git"
                     };
+
+                    manifest.Metadata.SetProjectUrl(repositoryUrl);
                 }));
 
                 packageBuilderContext.Build();
@@ -248,6 +247,8 @@ namespace GprTool.Tests
                         Url = repositoryUrl,
                         Type = "git"
                     };
+
+                    manifest.Metadata.SetProjectUrl(repositoryUrl);
                 }));
 
                 packageBuilderContext.Build();
@@ -279,6 +280,8 @@ namespace GprTool.Tests
                         Url = currentRepositoryUrl,
                         Type = "git"
                     };
+
+                    manifest.Metadata.SetProjectUrl(currentRepositoryUrl);
                 }));
 
                 packageBuilderContext.Build();
@@ -301,6 +304,8 @@ namespace GprTool.Tests
                         Url = currentRepositoryUrl,
                         Type = repositoryType
                     };
+
+                    manifest.Metadata.SetProjectUrl(currentRepositoryUrl);
                 }));
 
                 packageBuilderContext.Build();


### PR DESCRIPTION
`Metadata.Repository.Url` appears to return null if `<repository type=... />` hasn't been set. This happens when a project is built with `dotnet pack` and the `RepositoryUrl` property. We need to use `Metadata.ProjectUrl` instead!