### PR TITLE
Find the repository url attribute when the type attribute is missing

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -15,6 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
+      fail-fast: false
     steps:
       
       - name: Checkout
@@ -40,6 +41,14 @@ jobs:
           dotnet build $GprToolCsprojPath -c Release /p:GeneratePackageOnBuild=True 
           dotnet test $GprToolTestsCsprojPath -c Release --logger:nunit --verbosity normal /p:IsRunningTests=True --results-directory $TestResultsDirectory
           
+      - name: Self publish tool
+        if: github.repository == 'jcansdale/gpr' && matrix.os == 'ubuntu-latest'
+        shell: pwsh
+        run: |
+          $WorkingDirectory = ".\${{ env.GITHUB_WORKSPACE }}"
+          $GprToolCsprojPath = Join-Path $WorkingDirectory src\GprTool\GprTool.csproj
+          dotnet run --project $GprToolCsprojPath -- push 'nupkgs/*.nupkg' -k ${{ secrets.GITHUB_TOKEN }}
+
       - name: Upload nupkg
         if: github.repository == 'jcansdale/gpr'
         uses: actions/upload-artifact@v2
@@ -58,12 +67,6 @@ jobs:
         with:
           name: nupkgs-ubuntu-latest
           path: ${{ github.workspace }}/nupkgs
-
-      - name: Self publish tool
-        shell: bash
-        run: |
-          dotnet tool install gpr --tool-path tools
-          tools/gpr push ${{ github.workspace }}/nupkgs/*.nupkg -k ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push nuget packages 
         if: github.ref == 'refs/heads/master'

--- a/GprTool.sln
+++ b/GprTool.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GprTool", "src\GprTool\GprT
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{C744FA9A-1AC3-4F05-990F-5D4079826FF1}"
 	ProjectSection(SolutionItems) = preProject
+		.github\workflows\docker.yml = .github\workflows\docker.yml
+		.github\workflows\dotnetcore.yml = .github\workflows\dotnetcore.yml
 		nuget.config = nuget.config
 		README.md = README.md
 		version.json = version.json

--- a/src/GprTool/GprTool.csproj
+++ b/src/GprTool/GprTool.csproj
@@ -13,8 +13,6 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>gpr</ToolCommandName>
     <RepositoryUrl>https://github.com/jcansdale/gpr</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PackageProjectUrl>https://github.com/jcansdale/gpr</PackageProjectUrl>
     <Title>GPR Tool</Title>
     <PackageDescription>A .NET Core tool for working the GitHub Package Registry.</PackageDescription>
     <AssemblyName>gpr</AssemblyName>

--- a/src/GprTool/NuGetUtilities.cs
+++ b/src/GprTool/NuGetUtilities.cs
@@ -116,7 +116,7 @@ namespace GprTool
             // This happens when a project is built with `dotnet pack` and the RepositoryUrl property.
             // We need to use Metadata.ProjectUrl instead!
             
-            return manifest.Metadata.Repository?.Url ?? manifest.Metadata.ProjectUrl?.ToString();
+            return manifest?.Metadata?.ProjectUrl?.ToString();
         }
 
         public static void RewriteNupkg(PackageFile packageFile, NuGetVersion nuGetVersion = null)

--- a/src/GprTool/NuGetUtilities.cs
+++ b/src/GprTool/NuGetUtilities.cs
@@ -73,7 +73,8 @@ namespace GprTool
         public static bool BuildOwnerAndRepositoryFromUrlFromNupkg(PackageFile packageFile)
         {
             var manifest = ReadNupkgManifest(packageFile.FilenameAbsolutePath);
-            return BuildOwnerAndRepositoryFromUrl(packageFile, FindRepositoryUrl(manifest));
+            
+            return BuildOwnerAndRepositoryFromUrl(packageFile, manifest.Metadata.Repository?.Url);
         }
 
         public static PackageFile BuildPackageFile(string filename, string repositoryUrl)
@@ -107,16 +108,7 @@ namespace GprTool
                 return true;
             }
             
-            return !string.Equals(packageFile.RepositoryUrl, FindRepositoryUrl(manifest), StringComparison.OrdinalIgnoreCase);
-        }
-
-        static string FindRepositoryUrl(Manifest manifest)
-        {
-            // Metadata.Repository.Url appears to return null if <repository type=... /> hasn't been set.
-            // This happens when a project is built with `dotnet pack` and the RepositoryUrl property.
-            // We need to use Metadata.ProjectUrl instead!
-            
-            return manifest?.Metadata?.ProjectUrl?.ToString();
+            return !string.Equals(packageFile.RepositoryUrl, manifest.Metadata.Repository?.Url, StringComparison.OrdinalIgnoreCase);
         }
 
         public static void RewriteNupkg(PackageFile packageFile, NuGetVersion nuGetVersion = null)

--- a/test/GprTool.Tests/NuGetUtilitiesTests.cs
+++ b/test/GprTool.Tests/NuGetUtilitiesTests.cs
@@ -182,25 +182,20 @@ namespace GprTool.Tests
                 Assert.That(packageFile.RepositoryUrl, Is.EqualTo(expectedGithubRepositoryUrl));
             }
 
-            [TestCase("http://github.com/jcansdale/gpr", "git", "jcansdale", "gpr", "https://github.com/jcansdale/gpr")]
-            [TestCase("https://github.com/jcansdale/gpr", "git", "jcansdale", "gpr", "https://github.com/jcansdale/gpr")]
-            [TestCase("https://github.com/jcansdale\\gpr", "git", "jcansdale", "gpr", "https://github.com/jcansdale/gpr")]
-            [TestCase("https://github.com/jcansdale///////gpr", "git", "jcansdale", "gpr", "https://github.com/jcansdale/gpr")]
-            [TestCase("  https://github.com/jcansdale/gpr ", "git", "jcansdale", "gpr", "https://github.com/jcansdale/gpr", Description = "Whitespace")]
-            [TestCase("http://github.com/jcansdale/gpr", null, "jcansdale", "gpr", "https://github.com/jcansdale/gpr")]
-            public void BuildOwnerAndRepositoryFromUrlFromNupkg(string repositoryUrl, string repositoryType, string expectedOwner, string expectedRepositoryName, string expectedGithubRepositoryUrl)
+            [TestCase("http://github.com/jcansdale/gpr", "jcansdale", "gpr", "https://github.com/jcansdale/gpr")]
+            [TestCase("https://github.com/jcansdale/gpr", "jcansdale", "gpr", "https://github.com/jcansdale/gpr")]
+            [TestCase("https://github.com/jcansdale\\gpr", "jcansdale", "gpr", "https://github.com/jcansdale/gpr")]
+            [TestCase("https://github.com/jcansdale///////gpr", "jcansdale", "gpr", "https://github.com/jcansdale/gpr")]
+            [TestCase("  https://github.com/jcansdale/gpr ", "jcansdale", "gpr", "https://github.com/jcansdale/gpr", Description = "Whitespace")]
+            public void BuildOwnerAndRepositoryFromUrlFromNupkg(string repositoryUrl, string expectedOwner, string expectedRepositoryName, string expectedGithubRepositoryUrl)
             {
                 using var packageBuilderContext = new PackageBuilderContext(TmpDirectoryPath, new NuspecContext(manifest =>
                 {
-                    if (repositoryUrl is { } && repositoryType is { })
-                    {
-                        // Only create Repository when both Url and Type are specified 
-                        manifest.Metadata.Repository = new RepositoryMetadata
-                        {
-                            Url = repositoryUrl,
-                            Type = repositoryType
-                        };
-                    }
+                    manifest.Metadata.Repository = new RepositoryMetadata
+                    {                        
+                        Url = repositoryUrl,
+                        Type = "git"
+                    };
 
                     manifest.Metadata.SetProjectUrl(repositoryUrl);
                 }));

--- a/test/GprTool.Tests/NuGetUtilitiesTests.cs
+++ b/test/GprTool.Tests/NuGetUtilitiesTests.cs
@@ -182,6 +182,9 @@ namespace GprTool.Tests
                 Assert.That(packageFile.RepositoryUrl, Is.EqualTo(expectedGithubRepositoryUrl));
             }
 
+            [TestCase("jcansdale/gpr", "jcansdale", "gpr", "https://github.com/jcansdale/gpr")]
+            [TestCase("jcansdale//gpr", "jcansdale", "gpr", "https://github.com/jcansdale/gpr")]
+            [TestCase("/jcansdale/gpr", "jcansdale", "gpr", "https://github.com/jcansdale/gpr")]
             [TestCase("http://github.com/jcansdale/gpr", "jcansdale", "gpr", "https://github.com/jcansdale/gpr")]
             [TestCase("https://github.com/jcansdale/gpr", "jcansdale", "gpr", "https://github.com/jcansdale/gpr")]
             [TestCase("https://github.com/jcansdale\\gpr", "jcansdale", "gpr", "https://github.com/jcansdale/gpr")]
@@ -192,12 +195,10 @@ namespace GprTool.Tests
                 using var packageBuilderContext = new PackageBuilderContext(TmpDirectoryPath, new NuspecContext(manifest =>
                 {
                     manifest.Metadata.Repository = new RepositoryMetadata
-                    {                        
+                    {
                         Url = repositoryUrl,
                         Type = "git"
                     };
-
-                    manifest.Metadata.SetProjectUrl(repositoryUrl);
                 }));
 
                 packageBuilderContext.Build();
@@ -247,8 +248,6 @@ namespace GprTool.Tests
                         Url = repositoryUrl,
                         Type = "git"
                     };
-
-                    manifest.Metadata.SetProjectUrl(repositoryUrl);
                 }));
 
                 packageBuilderContext.Build();
@@ -280,8 +279,6 @@ namespace GprTool.Tests
                         Url = currentRepositoryUrl,
                         Type = "git"
                     };
-
-                    manifest.Metadata.SetProjectUrl(currentRepositoryUrl);
                 }));
 
                 packageBuilderContext.Build();
@@ -304,8 +301,6 @@ namespace GprTool.Tests
                         Url = currentRepositoryUrl,
                         Type = repositoryType
                     };
-
-                    manifest.Metadata.SetProjectUrl(currentRepositoryUrl);
                 }));
 
                 packageBuilderContext.Build();


### PR DESCRIPTION
_Note, I wanted to get this working again with minimal changes. I'm concerned it will be breaking people's builds. 😨_ 

`dotnet pack` will happily create a `<repository url="..." />` element that `Manifest.ReadFrom` isn't able to read. This is a fix for that.

### What this PR does

- Remove the `PackageProjectUrl` and `RepositoryType` properties
- Publish `gpr` too using itself
- Implement `ReadNupkgManifest` using `NuspecReader.Xml`
- Reverted previous misadventure 😉 

### Notes

I wasn't able to create a test .nupkg like this:

```
                    manifest.Metadata.Repository = new RepositoryMetadata
                    {
                        Url = repositoryUrl,
                        Type = null
                    };
```

...because without a `Type` no `<repository url="..."` element gets written.

The self-publish _does_ work, so I believe this is woking!

Fixes #60