### PR TITLE
Cleanup workflow

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -10,6 +10,7 @@ env:
   GprToolCsprojPath: src/GprTool/GprTool.csproj
   GprToolTestsCsprojPath: test/GprTool.Tests/GprTool.Tests.csproj
   TestResultsDirectory: TestResults
+  PackageOutputPath: nupkgs
 
 jobs:
 
@@ -48,14 +49,14 @@ jobs:
         if: github.repository == 'jcansdale/gpr' && matrix.os == 'ubuntu-latest'
         shell: bash
         run: |
-          dotnet run --project $GprToolCsprojPath -- push 'nupkgs/*.nupkg' -k ${{ secrets.GITHUB_TOKEN }}
+          dotnet run --project $GprToolCsprojPath -- push $PackageOutputPath -k ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload nupkg
         if: github.repository == 'jcansdale/gpr'
         uses: actions/upload-artifact@v2
         with:
           name: nupkgs-${{ matrix.os }}
-          path: ${{ github.workspace }}/nupkgs/**/*
+          path: ${{ github.workspace }}/$PackageOutputPath/**/*
         
   publish:
      if: github.repository == 'jcansdale/gpr'

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -34,10 +34,14 @@ jobs:
         with:
           setAllVars: true
           
-      - name: Build and test
+      - name: Build
         shell: bash
         run: |
           dotnet build $GprToolCsprojPath -c Release /p:GeneratePackageOnBuild=True
+          
+      - name: Test
+        shell: bash
+        run: |
           dotnet test $GprToolTestsCsprojPath -c Release --logger:nunit --verbosity normal /p:IsRunningTests=True --results-directory $TestResultsDirectory
           
       - name: Self publish tool

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -72,15 +72,8 @@ jobs:
 
       - name: Push nuget packages 
         if: github.ref == 'refs/heads/master'
-        shell: pwsh
-        run: | 
-          $WorkingDirectory = ".\${{ env.GITHUB_WORKSPACE }}"
-          $NupkgDirectory = Join-Path $WorkingDirectory nupkgs
-          $Nupkgs = Get-ChildItem $NupkgDirectory -Filter *.nupkg | Select-Object -ExpandProperty FullName
-          
-          $Nupkgs | ForEach-Object -Parallel {
-            dotnet nuget push $_ --source nuget.org --api-key ${{ secrets.NUGET_TOKEN }}   
-          }
+        shell: bash
+        run: dotnet nuget push $PackageOutputPath/*.nupkg --source nuget.org --api-key ${{ secrets.NUGET_TOKEN }}
           
       - name: Create github release tag
         if: success() && github.ref == 'refs/heads/master'

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -37,12 +37,12 @@ jobs:
       - name: Build
         shell: bash
         run: |
-          dotnet build $GprToolCsprojPath -c Release /p:GeneratePackageOnBuild=True
+          dotnet build $GprToolCsprojPath -c Release -p GeneratePackageOnBuild=True
           
       - name: Test
         shell: bash
         run: |
-          dotnet test $GprToolTestsCsprojPath -c Release --logger:nunit --verbosity normal /p:IsRunningTests=True --results-directory $TestResultsDirectory
+          dotnet test $GprToolTestsCsprojPath -c Release --logger:nunit --verbosity normal -p IsRunningTests=True --results-directory $TestResultsDirectory
           
       - name: Self publish tool
         if: github.repository == 'jcansdale/gpr' && matrix.os == 'ubuntu-latest'

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -6,6 +6,10 @@ env:
   NBGV_VERSION: 3.1.91
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1 
+  
+  GprToolCsprojPath: Join-Path $WorkingDirectory src/GprTool/GprTool.csproj
+  GprToolTestsCsprojPath: test/GprTool.Tests/GprTool.Tests.csproj
+  TestResultsDirectory: TestResults
 
 jobs:
 
@@ -31,22 +35,15 @@ jobs:
           setAllVars: true
           
       - name: Build and test
-        shell: pwsh
+        shell: bash
         run: |
-          
-          $WorkingDirectory = ".\${{ env.GITHUB_WORKSPACE }}"
-          $GprToolCsprojPath = Join-Path $WorkingDirectory src\GprTool\GprTool.csproj
-          $GprToolTestsCsprojPath = Join-Path $WorkingDirectory test\GprTool.Tests\GprTool.Tests.csproj
-          $TestResultsDirectory = Join-Path $WorkingDirectory TestResults
-          dotnet build $GprToolCsprojPath -c Release /p:GeneratePackageOnBuild=True 
+          dotnet build $GprToolCsprojPath -c Release /p:GeneratePackageOnBuild=True
           dotnet test $GprToolTestsCsprojPath -c Release --logger:nunit --verbosity normal /p:IsRunningTests=True --results-directory $TestResultsDirectory
           
       - name: Self publish tool
         if: github.repository == 'jcansdale/gpr' && matrix.os == 'ubuntu-latest'
-        shell: pwsh
+        shell: bash
         run: |
-          $WorkingDirectory = ".\${{ env.GITHUB_WORKSPACE }}"
-          $GprToolCsprojPath = Join-Path $WorkingDirectory src\GprTool\GprTool.csproj
           dotnet run --project $GprToolCsprojPath -- push 'nupkgs/*.nupkg' -k ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload nupkg

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -37,12 +37,12 @@ jobs:
       - name: Build
         shell: bash
         run: |
-          dotnet build $GprToolCsprojPath -c Release -p GeneratePackageOnBuild=True
+          dotnet build $GprToolCsprojPath -c Release -p:GeneratePackageOnBuild=True
           
       - name: Test
         shell: bash
         run: |
-          dotnet test $GprToolTestsCsprojPath -c Release --logger:nunit --verbosity normal -p IsRunningTests=True --results-directory $TestResultsDirectory
+          dotnet test $GprToolTestsCsprojPath -c Release --logger:nunit --verbosity normal -p:IsRunningTests=True --results-directory $TestResultsDirectory
           
       - name: Self publish tool
         if: github.repository == 'jcansdale/gpr' && matrix.os == 'ubuntu-latest'

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -59,7 +59,7 @@ jobs:
           path: ${{ github.workspace }}/${{ env.PackageOutputPath }}/**/*
         
   publish:
-     if: github.repository == 'jcansdale/gpr'
+     if: github.repository == 'jcansdale/gpr' && github.ref == 'refs/heads/master'
      runs-on: ubuntu-latest
      name: Publish nuget packages
      needs: [build-and-test]
@@ -68,7 +68,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: nupkgs-ubuntu-latest
-          path: ${{ github.workspace }}/nupkgs
+          path: ${{ github.workspace }}/${{ env.PackageOutputPath }}
 
       - name: Push nuget packages 
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -7,7 +7,7 @@ env:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1 
   
-  GprToolCsprojPath: Join-Path $WorkingDirectory src/GprTool/GprTool.csproj
+  GprToolCsprojPath: src/GprTool/GprTool.csproj
   GprToolTestsCsprojPath: test/GprTool.Tests/GprTool.Tests.csproj
   TestResultsDirectory: TestResults
 

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: nupkgs-${{ matrix.os }}
-          path: ${{ github.workspace }}/$PackageOutputPath/**/*
+          path: ${{ github.workspace }}/${{ env.PackageOutputPath }}/**/*
         
   publish:
      if: github.repository == 'jcansdale/gpr'


### PR DESCRIPTION
- Simplify envvars
- Use `PackageOutputPath`
- Use `bash` as x-plat shell