### PR TITLE
No policy when NuGet warnings are returned

### DIFF
--- a/src/GprTool/Program.cs
+++ b/src/GprTool/Program.cs
@@ -526,6 +526,13 @@ namespace GprTool
                     return response;
                 }
 
+                if (response.StatusCode == HttpStatusCode.NotFound)
+                {
+                    Console.WriteLine($"[{packageFile.Filename}]: {response.StatusDescription}");
+                    Console.WriteLine($"[{packageFile.Filename}]: Check that '{packageFile.RepositoryUrl}' exists");
+                    return response;
+                }
+
                 Console.WriteLine($"[{packageFile.Filename}]: {response.StatusDescription}");
                 foreach (var header in response.Headers)
                 {

--- a/src/GprTool/Program.cs
+++ b/src/GprTool/Program.cs
@@ -370,6 +370,7 @@ namespace GprTool
             var retryPolicy = Policy
                 // http://restsharp.org/usage/exceptions.html
                 .HandleResult<IRestResponse>(x => FindWarning(x) is null
+                                                  && x.StatusCode != HttpStatusCode.NotFound
                                                   && x.StatusCode != HttpStatusCode.Unauthorized
                                                   && x.StatusCode != HttpStatusCode.Conflict
                                                   && x.StatusCode != HttpStatusCode.BadRequest

--- a/src/GprTool/Program.cs
+++ b/src/GprTool/Program.cs
@@ -369,7 +369,8 @@ namespace GprTool
 
             var retryPolicy = Policy
                 // http://restsharp.org/usage/exceptions.html
-                .HandleResult<IRestResponse>(x => x.StatusCode != HttpStatusCode.Unauthorized
+                .HandleResult<IRestResponse>(x => FindWarning(x) is null
+                                                  && x.StatusCode != HttpStatusCode.Unauthorized
                                                   && x.StatusCode != HttpStatusCode.Conflict
                                                   && x.StatusCode != HttpStatusCode.BadRequest
                                                   && x.StatusCode != HttpStatusCode.OK)
@@ -518,11 +519,9 @@ namespace GprTool
                     return response;
                 }
 
-                var nugetWarning = response.Headers.FirstOrDefault(h =>
-                    h.Name.Equals("X-Nuget-Warning", StringComparison.OrdinalIgnoreCase));
-                if (nugetWarning != null)
+                if (FindWarning(response) is { } warning)
                 {
-                    Console.WriteLine($"[{packageFile.Filename}]: {nugetWarning.Value}");
+                    Console.WriteLine($"[{packageFile.Filename}]: {warning}");
                     return response;
                 }
 
@@ -536,6 +535,12 @@ namespace GprTool
             }
 
             return packageFiles.All(x => x.IsUploaded) ? 0 : 1;
+        }
+
+        static string FindWarning(IRestResponse response)
+        {
+            return response.Headers.FirstOrDefault(h =>
+                h.Name.Equals("X-Nuget-Warning", StringComparison.OrdinalIgnoreCase))?.Value as string;
         }
 
         [Argument(0, Description = "Path to the package file")]


### PR DESCRIPTION
- Don't keep trying or stop when a NuGet warning is returned
- Don't keep trying or stop when HTTP status 404 / NotFound is returned
- Ask users if repository exists when a 404 / NotFound is returned

Fixes #67 