### PR TITLE
Add support for pushing multiple globs/files

### DIFF
--- a/src/GprTool/IoExtensions.cs
+++ b/src/GprTool/IoExtensions.cs
@@ -8,16 +8,18 @@ namespace GprTool
 {
     public static class IoExtensions
     {
-        public static IEnumerable<string> GetFilesByGlobPattern(this string baseDirectory, string[] globPatterns, out Glob outGlob)
+        public static IEnumerable<string> GetFilesByGlobPattern(this string baseDirectory, string[] globPatterns, out string outGlobs)
         {
-            outGlob = null;
+            var globList = new List<Glob>();
 
             var files = Enumerable.Empty<string>();
             foreach (var globPattern in globPatterns)
             {
-                files = files.Concat(GetFilesByGlobPattern(baseDirectory, globPattern, out outGlob));
+                files = files.Concat(GetFilesByGlobPattern(baseDirectory, globPattern, out Glob outGlob));
+                globList.Add(outGlob);
             }
 
+            outGlobs = string.Join(' ', globList);
             return files;
         }
 

--- a/src/GprTool/IoExtensions.cs
+++ b/src/GprTool/IoExtensions.cs
@@ -8,6 +8,19 @@ namespace GprTool
 {
     public static class IoExtensions
     {
+        public static IEnumerable<string> GetFilesByGlobPattern(this string baseDirectory, string[] globPatterns, out Glob outGlob)
+        {
+            outGlob = null;
+
+            var files = Enumerable.Empty<string>();
+            foreach (var globPattern in globPatterns)
+            {
+                files = files.Concat(GetFilesByGlobPattern(baseDirectory, globPattern, out outGlob));
+            }
+
+            return files;
+        }
+
         public static IEnumerable<string> GetFilesByGlobPattern(this string baseDirectory, string globPattern, out Glob outGlob)
         {
             var baseDirectoryGlobPattern = Path.GetFullPath(Path.Combine(baseDirectory, globPattern));

--- a/src/GprTool/Program.cs
+++ b/src/GprTool/Program.cs
@@ -397,7 +397,7 @@ namespace GprTool
             var currentDirectory = Directory.GetCurrentDirectory();
             packageFiles.AddRange(
                 currentDirectory
-                    .GetFilesByGlobPattern(GlobPattern, out var glob)
+                    .GetFilesByGlobPattern(GlobPatterns, out var glob)
                     .Select(x => NuGetUtilities.BuildPackageFile(x, RepositoryUrl)));
 
             if (!packageFiles.Any())
@@ -552,7 +552,7 @@ namespace GprTool
         }
 
         [Argument(0, Description = "Path to the package file")]
-        public string GlobPattern { get; set; }
+        public string[] GlobPatterns { get; set; }
 
         [Option("-r|--repository", Description = "Override current nupkg repository url. Format: owner/repository. E.g: jcansdale/gpr")]
         public string RepositoryUrl { get; set; }

--- a/test/GprTool.Tests/IoExtensionsTests.cs
+++ b/test/GprTool.Tests/IoExtensionsTests.cs
@@ -230,5 +230,27 @@ namespace GprTool.Tests
             Assert.That(packages, Does.Contain(nupkgAbsoluteFilename));
             Assert.That(packages, Does.Contain(snupkgAbsoluteFilename));
         }
+
+        [Test]
+        public void GetFilesByGlobPatterns_Is_Multiple_FullPath_Filenames()
+        {
+            using var tmpDirectory = new DisposableDirectory(Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString("N")));
+
+            var nupkgAbsoluteFilename = Path.Combine(tmpDirectory, "test.nupkg");
+            var snupkgAbsoluteFilename = Path.Combine(tmpDirectory, "test.snupkg");
+            var bogusNupkgAbsoluteFilename = Path.Combine(tmpDirectory, "testbogus.snupkg");
+
+            File.WriteAllText(nupkgAbsoluteFilename, string.Empty);
+            File.WriteAllText(snupkgAbsoluteFilename, string.Empty);
+            File.WriteAllText(bogusNupkgAbsoluteFilename, string.Empty);
+
+            var packages = tmpDirectory.WorkingDirectory.GetFilesByGlobPattern(new[] { nupkgAbsoluteFilename, snupkgAbsoluteFilename }, out var glob).ToList();
+
+            Assert.That(glob.ToString(), Is.EqualTo($"{nupkgAbsoluteFilename} {snupkgAbsoluteFilename}"));
+
+            Assert.That(packages.Count, Is.EqualTo(2));
+            Assert.That(packages, Does.Contain(nupkgAbsoluteFilename));
+            Assert.That(packages, Does.Contain(snupkgAbsoluteFilename));
+        }
     }
 }


### PR DESCRIPTION
Let the `gpr push` command accept multiple files/glob patterns.

Not a fix for https://github.com/jcansdale/gpr/issues/70. That can be a separate PR.

Fixes #71