### PR TITLE
List or delete all packages

### DIFF
--- a/src/GprTool/GraphQLUtilities.cs
+++ b/src/GprTool/GraphQLUtilities.cs
@@ -8,8 +8,13 @@ namespace GprTool
 {
     public class GraphQLUtilities
     {
+        public static async Task<IQueryableList<Package>> FindPackageList(IConnection connection, string packagesPath)
+        {
+            var packageConnection = await FindPackageConnection(connection, packagesPath);
+            return packageConnection?.AllPages();
+        }
 
-        public static async Task<PackageConnection> FindPackageConnection(IConnection connection, string packagesPath, int first = 100)
+        static async Task<PackageConnection> FindPackageConnection(IConnection connection, string packagesPath)
         {
             var split = packagesPath.Split('/');
             var owner = split.Length > 0 ? split[0] : null;
@@ -18,14 +23,14 @@ namespace GprTool
 
             if (repo is string)
             {
-                return new Query().Repository(owner: owner, name: repo).Packages(first: first, names: names);
+                return new Query().Repository(owner: owner, name: repo).Packages(names: names);
             }
 
             try
             {
                 var query = new Query().User(owner).Packages().Select(p => p.TotalCount).Compile();
                 var total = await connection.Run(query);
-                return new Query().User(owner).Packages(first: first);
+                return new Query().User(owner).Packages();
             }
             catch (GraphQLException e) when (e.Message.StartsWith("Could not resolve to a "))
             {
@@ -40,7 +45,7 @@ namespace GprTool
             {
                 var query = new Query().Organization(owner).Packages().Select(p => p.TotalCount).Compile();
                 var total = await connection.Run(query);
-                return new Query().Organization(owner).Packages(first: first);
+                return new Query().Organization(owner).Packages();
             }
             catch (GraphQLException e) when (e.Message.StartsWith("Could not resolve to a "))
             {

--- a/src/GprTool/Program.cs
+++ b/src/GprTool/Program.cs
@@ -174,11 +174,9 @@ namespace GprTool
                 {
                     p.Repository.Url,
                     p.Name,
-                    Versions = p.Versions(100, null, null, null, null).Nodes.Select(v =>
+                    Versions = p.Versions(null, null, null, null, null).AllPages().Select(v =>
                     new
                     {
-                        p.Repository.Url,
-                        p.Name,
                         v.Id,
                         v.Version,
                         v.Statistics.DownloadsTotalCount

--- a/src/GprTool/Program.cs
+++ b/src/GprTool/Program.cs
@@ -84,14 +84,14 @@ namespace GprTool
                 return 1;
             }
 
-            var packageCollection = await GraphQLUtilities.FindPackageConnection(connection, PackagesPath);
-            if (packageCollection == null)
+            var packageList = await GraphQLUtilities.FindPackageList(connection, PackagesPath);
+            if (packageList == null)
             {
                 Console.WriteLine("Couldn't find packages");
                 return 1;
             }
 
-            var query = packageCollection.Nodes.Select(p =>
+            var query = packageList.Select(p =>
                 new
                 {
                     p.Name,
@@ -162,14 +162,14 @@ namespace GprTool
                 return 1;
             }
 
-            var packageCollection = await GraphQLUtilities.FindPackageConnection(connection, PackagesPath);
-            if (packageCollection == null)
+            var packageList = await GraphQLUtilities.FindPackageList(connection, PackagesPath);
+            if (packageList == null)
             {
                 Console.WriteLine("Couldn't find packages");
                 return 1;
             }
 
-            var query = packageCollection.Nodes.Select(p =>
+            var query = packageList.Select(p =>
                 new
                 {
                     p.Repository.Url,

--- a/src/GprTool/Program.cs
+++ b/src/GprTool/Program.cs
@@ -317,7 +317,7 @@ namespace GprTool
                     Name = p.Name,
                     PackageType = p.PackageType,
                     DownloadsTotalCount = p.Statistics.DownloadsTotalCount,
-                    Versions = p.Versions(100, null, null, null, null).Nodes.Select(v => v.Version).ToList()
+                    Versions = p.Versions(null, null, null, null, null).AllPages().Select(v => v.Version).ToList()
                 })
                 .Compile();
 

--- a/src/GprTool/Program.cs
+++ b/src/GprTool/Program.cs
@@ -96,7 +96,7 @@ namespace GprTool
                 {
                     p.Name,
                     p.Statistics.DownloadsTotalCount,
-                    Versions = p.Versions(100, null, null, null, null).Nodes.Select(v =>
+                    Versions = p.Versions(null, null, null, null, null).AllPages().Select(v =>
                     new
                     {
                         v.Version,

--- a/src/GprTool/Program.cs
+++ b/src/GprTool/Program.cs
@@ -101,7 +101,7 @@ namespace GprTool
                     {
                         v.Version,
                         v.Statistics.DownloadsTotalCount,
-                        Files = v.Files(40, null, null, null, null).Nodes.Select(f => new { f.Name, f.UpdatedAt, f.Size }).ToList()
+                        Files = v.Files(null, null, null, null, null).AllPages(40).Select(f => new { f.Name, f.UpdatedAt, f.Size }).ToList()
                     }).ToList()
                 }).Compile();
 


### PR DESCRIPTION
This PR fixes pagination for the `files`, `delete`, and `list` commands. There _shouldn't_ be any more limits on the number of packages, package versions or files!

Fixes #75