### PR TITLE
Don't split spaces

### DIFF
--- a/src/GprTool/IoExtensions.cs
+++ b/src/GprTool/IoExtensions.cs
@@ -8,8 +8,10 @@ namespace GprTool
 {
     public static class IoExtensions
     {
-        public static IEnumerable<string> GetFilesByGlobPattern(this string baseDirectory, string[] globPatterns, out string outGlobs)
+        public static IEnumerable<string> GetFilesByGlobPatterns(this string baseDirectory, string[] globPatterns, out string outGlobs)
         {
+            globPatterns = globPatterns ?? throw new ArgumentNullException(nameof(globPatterns));
+
             var globList = new List<Glob>();
 
             var files = Enumerable.Empty<string>();
@@ -25,6 +27,8 @@ namespace GprTool
 
         public static IEnumerable<string> GetFilesByGlobPattern(this string baseDirectory, string globPattern, out Glob outGlob)
         {
+            globPattern = globPattern ?? throw new ArgumentNullException(nameof(globPattern));
+
             var baseDirectoryGlobPattern = Path.GetFullPath(Path.Combine(baseDirectory, globPattern.Trim()));
             var fileNames = new List<string>();
 

--- a/src/GprTool/IoExtensions.cs
+++ b/src/GprTool/IoExtensions.cs
@@ -28,10 +28,7 @@ namespace GprTool
             var baseDirectoryGlobPattern = Path.GetFullPath(Path.Combine(baseDirectory, globPattern.Trim()));
             var fileNames = new List<string>();
 
-            if (string.Equals(".", globPattern))
-            {
-                globPattern = Path.GetFullPath(Path.Combine(baseDirectory, "*.*"));
-            } else if (Directory.Exists(baseDirectoryGlobPattern))
+            if (Directory.Exists(baseDirectoryGlobPattern))
             {
                 globPattern = Path.GetFullPath(Path.Combine(baseDirectoryGlobPattern, "*.*"));
             } else if (File.Exists(baseDirectoryGlobPattern))

--- a/src/GprTool/IoExtensions.cs
+++ b/src/GprTool/IoExtensions.cs
@@ -25,7 +25,7 @@ namespace GprTool
 
         public static IEnumerable<string> GetFilesByGlobPattern(this string baseDirectory, string globPattern, out Glob outGlob)
         {
-            var baseDirectoryGlobPattern = Path.GetFullPath(Path.Combine(baseDirectory, globPattern));
+            var baseDirectoryGlobPattern = Path.GetFullPath(Path.Combine(baseDirectory, globPattern.Trim()));
             var fileNames = new List<string>();
 
             if (string.Equals(".", globPattern))

--- a/src/GprTool/IoExtensions.cs
+++ b/src/GprTool/IoExtensions.cs
@@ -37,18 +37,6 @@ namespace GprTool
             } else if (File.Exists(baseDirectoryGlobPattern))
             {
                 globPattern = Path.GetFullPath(baseDirectoryGlobPattern);
-            } else if (globPattern.Contains(" "))
-            {
-                baseDirectoryGlobPattern = baseDirectory;
-
-                fileNames.AddRange(globPattern
-                    .Split(" ", StringSplitOptions.RemoveEmptyEntries)
-                    .Select(x => Path.IsPathRooted(x)
-                        ? Path.GetFullPath(x)
-                        : Path.GetFullPath(Path.Combine(baseDirectoryGlobPattern, x)))
-                    .Where(x => !Directory.Exists(x)));
-
-                globPattern = string.Empty;
             }
 
             var glob = Path.IsPathRooted(globPattern)

--- a/src/GprTool/Program.cs
+++ b/src/GprTool/Program.cs
@@ -397,7 +397,7 @@ namespace GprTool
             var currentDirectory = Directory.GetCurrentDirectory();
             packageFiles.AddRange(
                 currentDirectory
-                    .GetFilesByGlobPattern(GlobPatterns, out var glob)
+                    .GetFilesByGlobPatterns(GlobPatterns, out var glob)
                     .Select(x => NuGetUtilities.BuildPackageFile(x, RepositoryUrl)));
 
             if (!packageFiles.Any())

--- a/src/GprTool/Program.cs
+++ b/src/GprTool/Program.cs
@@ -385,7 +385,11 @@ namespace GprTool
         protected override async Task<int> OnExecuteAsyncImpl(CommandLineApplication app,
             CancellationToken cancellationToken)
         {
-            var packageFiles = new List<PackageFile>();
+            if (GlobPatterns is null)
+            {
+                Console.WriteLine("Please include a package path or glob pattern.");
+                return 1;
+            }
 
             NuGetVersion nuGetVersion = null;
             if (Version != null && !NuGetVersion.TryParse(Version, out nuGetVersion))
@@ -394,6 +398,7 @@ namespace GprTool
                 return 1;
             }
 
+            var packageFiles = new List<PackageFile>();
             var currentDirectory = Directory.GetCurrentDirectory();
             packageFiles.AddRange(
                 currentDirectory

--- a/test/GprTool.Tests/IoExtensionsTests.cs
+++ b/test/GprTool.Tests/IoExtensionsTests.cs
@@ -185,33 +185,6 @@ namespace GprTool.Tests
             Assert.That(packages, Does.Contain(snupkgAbsoluteFilename));
         }
 
-
-        [TestCase("test.nupkg test.snupkg")]
-        [TestCase("./test.nupkg ./test.snupkg")]
-        [TestCase("./test.nupkg              ./test.snupkg", Description = "Whitespace")]
-#if PLATFORM_WINDOWS
-        [TestCase(".\\test.nupkg .\\test.snupkg")]
-#endif
-        public void GetFilesByGlobPattern_Is_Multiple_Relative_Filenames(string relativeFilename)
-        {
-            using var tmpDirectory = new DisposableDirectory(Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString("N")));
-
-            var nupkgAbsoluteFilename = Path.Combine(tmpDirectory, "test.nupkg");
-            var snupkgAbsoluteFilename = Path.Combine(tmpDirectory, "test.snupkg");
-            var bogusNupkgAbsoluteFilename = Path.Combine(tmpDirectory, "testbogus.snupkg");
-
-            File.WriteAllText(nupkgAbsoluteFilename, string.Empty);
-            File.WriteAllText(snupkgAbsoluteFilename, string.Empty);
-            File.WriteAllText(bogusNupkgAbsoluteFilename, string.Empty);
-
-            var packages = tmpDirectory.WorkingDirectory.GetFilesByGlobPattern(relativeFilename, out var glob).ToList();
-
-            Assert.That(glob.ToString(), Is.EqualTo(tmpDirectory.WorkingDirectory));
-            Assert.That(packages.Count, Is.EqualTo(2));
-            Assert.That(packages, Does.Contain(nupkgAbsoluteFilename));
-            Assert.That(packages, Does.Contain(snupkgAbsoluteFilename));
-        }
-
         [Test]
         public void GetFilesByGlobPattern_Is_FullPath_Filename()
         {
@@ -234,28 +207,6 @@ namespace GprTool.Tests
             Assert.That(globPattern, Is.EqualTo("test.nupkg"));
             Assert.That(packages.Count, Is.EqualTo(1));
             Assert.That(packages, Does.Contain(nupkgAbsoluteFilename));
-        }
-
-        [Test]
-        public void GetFilesByGlobPattern_Is_Multiple_FullPath_Filenames()
-        {
-            using var tmpDirectory = new DisposableDirectory(Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString("N")));
-
-            var nupkgAbsoluteFilename = Path.Combine(tmpDirectory, "test.nupkg");
-            var snupkgAbsoluteFilename = Path.Combine(tmpDirectory, "test.snupkg");
-            var bogusNupkgAbsoluteFilename = Path.Combine(tmpDirectory, "testbogus.snupkg");
-
-            File.WriteAllText(nupkgAbsoluteFilename, string.Empty);
-            File.WriteAllText(snupkgAbsoluteFilename, string.Empty);
-            File.WriteAllText(bogusNupkgAbsoluteFilename, string.Empty);
-
-            var packages = tmpDirectory.WorkingDirectory.GetFilesByGlobPattern(nupkgAbsoluteFilename + " " + snupkgAbsoluteFilename, out var glob).ToList();
-
-            Assert.That(glob.ToString(), Is.EqualTo(tmpDirectory.WorkingDirectory));
-
-            Assert.That(packages.Count, Is.EqualTo(2));
-            Assert.That(packages, Does.Contain(nupkgAbsoluteFilename));
-            Assert.That(packages, Does.Contain(snupkgAbsoluteFilename));
         }
 
         [Test]

--- a/test/GprTool.Tests/IoExtensionsTests.cs
+++ b/test/GprTool.Tests/IoExtensionsTests.cs
@@ -37,6 +37,20 @@ namespace GprTool.Tests
             Assert.That(packages.Count(), Is.EqualTo(expectedPaths.Count()));
         }
 
+        [Test]
+        public void GetFilesByGlobPattern_Throws_ArgumentNullException()
+        {
+            var ex = Assert.Throws<ArgumentNullException>(() =>
+                Path.GetTempPath().GetFilesByGlobPattern(null as string, out var glob));
+        }
+
+        [Test]
+        public void GetFilesByGlobPatterns_Throws_ArgumentNullException()
+        {
+            var ex = Assert.Throws<ArgumentNullException>(() =>
+                Path.GetTempPath().GetFilesByGlobPatterns(null as string[], out var glob));
+        }
+
         [TestCase("./nupkg", "*.*", 2)]
         [TestCase("./nupkg/**/*.*", "**/*.*", 2)]
         [TestCase("./nupkg/**/**", "**/**", 2)]
@@ -179,7 +193,7 @@ namespace GprTool.Tests
             File.WriteAllText(bogusNupkgAbsoluteFilename, string.Empty);
 
             var globPatterns = relativeFilenames.Split(';');
-            var packages = tmpDirectory.WorkingDirectory.GetFilesByGlobPattern(globPatterns, out var globs).ToList();
+            var packages = tmpDirectory.WorkingDirectory.GetFilesByGlobPatterns(globPatterns, out var globs).ToList();
 
             Assert.That(globs, Does.Contain(' '));
             Assert.That(packages.Count, Is.EqualTo(2));
@@ -224,7 +238,7 @@ namespace GprTool.Tests
             File.WriteAllText(snupkgAbsoluteFilename, string.Empty);
             File.WriteAllText(bogusNupkgAbsoluteFilename, string.Empty);
 
-            var packages = tmpDirectory.WorkingDirectory.GetFilesByGlobPattern(new[] { nupkgAbsoluteFilename, snupkgAbsoluteFilename }, out var glob).ToList();
+            var packages = tmpDirectory.WorkingDirectory.GetFilesByGlobPatterns(new[] { nupkgAbsoluteFilename, snupkgAbsoluteFilename }, out var glob).ToList();
 
             Assert.That(glob.ToString(), Is.EqualTo($"{nupkgAbsoluteFilename} {snupkgAbsoluteFilename}"));
 

--- a/test/GprTool.Tests/IoExtensionsTests.cs
+++ b/test/GprTool.Tests/IoExtensionsTests.cs
@@ -10,6 +10,7 @@ namespace GprTool.Tests
     {
         [TestCase("foo.nupkg", "foo.nupkg", "foo.nupkg")]
         [TestCase("*.nupkg", "foo.nupkg;bar.nupkg", "foo.nupkg;bar.nupkg")]
+        [TestCase(".", "foo.nupkg;bar.nupkg", "foo.nupkg;bar.nupkg")]
         [TestCase("*.nupkg", "foo bar.nupkg", "foo bar.nupkg")]
         [TestCase("dir/foo.nupkg", "dir/foo.nupkg", "dir/foo.nupkg")]
         [TestCase("foo bar/baz.nupkg", "foo bar/baz.nupkg", "foo bar/baz.nupkg")]

--- a/test/GprTool.Tests/IoExtensionsTests.cs
+++ b/test/GprTool.Tests/IoExtensionsTests.cs
@@ -15,6 +15,7 @@ namespace GprTool.Tests
         [TestCase("dir/foo.nupkg", "dir/foo.nupkg", "dir/foo.nupkg")]
         [TestCase("foo bar/baz.nupkg", "foo bar/baz.nupkg", "foo bar/baz.nupkg")]
         [TestCase("foo bar/baz.*", "foo bar/baz.nupkg", "foo bar/baz.nupkg")]
+        [TestCase("test.*", "test.nupkg;test.snupkg;test.zip", "test.nupkg;test.snupkg")]
         public void GetFilesByGlobPattern(string globPattern, string files, string expectedFiles)
         {
             using var tmpDirectory = new DisposableDirectory(Path.Combine(Directory.GetCurrentDirectory(), Guid.NewGuid().ToString("N")));


### PR DESCRIPTION
Now that multiple globs can be passed in as args, we don't need to support separating globs with whitespace.

### What this PR does

- Add test for glob with space
https://github.com/jcansdale/gpr/blob/9352233faf97c6a961df726a1624c4c09ceeac3e/test/GprTool.Tests/IoExtensionsTests.cs#L16
- Remove support for separating globs with whitespace
- Don't special case `.` (treat it as a regular directory)
- Add null check for glob patterns (a package path or glob must be passed)

Fixes #70