### PR TITLE
Add option to delete specific version

### DIFF
--- a/src/GprTool/Program.cs
+++ b/src/GprTool/Program.cs
@@ -259,7 +259,7 @@ namespace GprTool
                 foreach (var package in packages)
                 {
                     Console.WriteLine(package.Name);
-                    foreach (var version in package.Versions)
+                    foreach (var version in package.Versions.Where(v => Version is null || v.Version == Version))
                     {
                         if (Force)
                         {
@@ -314,6 +314,9 @@ namespace GprTool
 
         [Option("--force", Description = "Delete all package versions")]
         protected bool Force { get; set; }
+
+        [Option("-v|--version", Description = "The version to delete")]
+        public string Version { get; set; }
     }
 
     [Command(Description = "List packages for user or org (viewer if not specified)")]


### PR DESCRIPTION
Add a simple filter to allow a specific version names to be deleted. This is a pale imitation of what we would like to do in #77!

I've manually tested it and it seems to work:

```
gpr delete jcansdale-test/maven-test/com.mycompany.app.my-app -k $GITHUB_TOKEN --version 0.111-SNAPSHOT --force

com.mycompany.app.my-app
  Deleting '0.111-SNAPSHOT'
Public package versions are not eligible for deletion. For more on our deletion policy, see https://docs.github.com/articles/about-github-package-registry/#deleting-a-package.
```

This is expected for public packages. ☝️ 

Fixes #86