### PR TITLE
Strip any NuGet version metadata

### DIFF
--- a/src/GprTool/NuGetUtilities.cs
+++ b/src/GprTool/NuGetUtilities.cs
@@ -125,17 +125,9 @@ namespace GprTool
 
             var manifest = ReadNupkgManifest(packageFile.FilenameAbsolutePath);
 
-            if (nuGetVersion != null)
+            if (nuGetVersion != null && !nuGetVersion.ToFullString().Equals(manifest.Metadata.Version.ToFullString()))
             {
-                if (!nuGetVersion.Equals(manifest.Metadata.Version))
-                {
-                    return true;
-                }
-
-                if (!nuGetVersion.Metadata.Equals(manifest.Metadata.Version.Metadata))
-                {
-                    return true;
-                }
+                return true;
             }
 
             return !string.Equals(packageFile.RepositoryUrl, manifest.Metadata.Repository?.Url, StringComparison.OrdinalIgnoreCase);

--- a/src/GprTool/NuGetUtilities.cs
+++ b/src/GprTool/NuGetUtilities.cs
@@ -125,11 +125,19 @@ namespace GprTool
 
             var manifest = ReadNupkgManifest(packageFile.FilenameAbsolutePath);
 
-            if (nuGetVersion != null && !nuGetVersion.Equals(manifest.Metadata.Version))
+            if (nuGetVersion != null)
             {
-                return true;
+                if (!nuGetVersion.Equals(manifest.Metadata.Version))
+                {
+                    return true;
+                }
+
+                if (!nuGetVersion.Metadata.Equals(manifest.Metadata.Version.Metadata))
+                {
+                    return true;
+                }
             }
-            
+
             return !string.Equals(packageFile.RepositoryUrl, manifest.Metadata.Repository?.Url, StringComparison.OrdinalIgnoreCase);
         }
 

--- a/src/GprTool/Program.cs
+++ b/src/GprTool/Program.cs
@@ -502,6 +502,17 @@ namespace GprTool
             {
                 if (packageFile == null) throw new ArgumentNullException(nameof(packageFile));
 
+                // Automatically strip metadata
+                if (nuGetVersion == null)
+                {
+                    var manifest = NuGetUtilities.ReadNupkgManifest(packageFile.FilenameAbsolutePath);
+                    if (manifest.Metadata.Version is { } version && version.HasMetadata)
+                    {
+                        nuGetVersion = new NuGetVersion(version.ToNormalizedString());
+                        Console.WriteLine($"[{packageFile.Filename}]: Stripping Metadata: {version.Metadata}, from Version: {version.ToFullString()}");
+                    }
+                }
+
                 cancellationToken.ThrowIfCancellationRequested();
 
                 NuGetVersion packageVersion;
@@ -525,7 +536,7 @@ namespace GprTool
 
                 Console.WriteLine($"[{packageFile.Filename}]: " +
                                   $"Repository url: {packageFile.RepositoryUrl}. " +
-                                  $"Version: {packageVersion}. " +
+                                  $"Version: {packageVersion.ToFullString()}. " +
                                   $"Size: {packageStream.Length} bytes. ");
 
                 await retryPolicy.ExecuteAndCaptureAsync(retryCancellationToken =>

--- a/test/GprTool.Tests/NuGetUtilitiesTests.cs
+++ b/test/GprTool.Tests/NuGetUtilitiesTests.cs
@@ -236,6 +236,7 @@ namespace GprTool.Tests
 
             [TestCase("1.0.0", "1.0.0", false)]
             [TestCase("1.0.0", "1.0.1", true)]
+            [TestCase("1.0.0+metadata", "1.0.0", true)]
             public void ShouldRewriteNupkg_Version(string currentVersion, string updatedVersion, bool shouldUpdateVersion)
             {
                 const string repositoryUrl = "https://github.com/jcansdale/gpr";


### PR DESCRIPTION
GitHub Packages isn't currently compatible with version metadata. Packages with metadata will upload successfully, but won't be accessible. This PR strips any metadata before uploading the package.

When a package version includes metadata, the output should look like:

```
Found 1 package.
[PackageWithMetadata.1.0.0.nupkg]: Stripping Metadata: metadata, from Version: 1.0.0+metadata
[PackageWithMetadata.1.0.0.nupkg]: Repository url: https://github.com/jcansdale-test/foo. Version: 1.0.0. Size: 5314 bytes.
[PackageWithMetadata.1.0.0.nupkg]: Uploading package.
```

### How to test

1. Copy this [nuget.config](https://github.com/jcansdale/gpr/blob/master/nuget.config) into a new directory
2. From the same directory do `dotnet tool update gpr --version 0.1.237-gadc903af74 -g`
3. Try pushing a package with a version that includes metadata (e.g. `gpr push your.pkg -k <PAT>`)

Fixes #92