### PR TITLE
Set RollForward=LatestMajor so the tool will run with newer runtimes.

### DIFF
--- a/src/GprTool/GprTool.csproj
+++ b/src/GprTool/GprTool.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
+    <RollForward>LatestMajor</RollForward>
     <Authors>Jamie Cansdale</Authors>
     <Company>Mutant Design Limited</Company>
     <Product>GprTool</Product>


### PR DESCRIPTION
This is to fix issues like this on .NET 5.0:

```
It was not possible to find any compatible framework version
The framework 'Microsoft.NETCore.App', version '3.0.0' was not found.
  - The following frameworks were found:
      5.0.0-preview.8.20407.11 at [C:\hostedtoolcache\windows\dncs\5.0.100-preview.8.20417.9\x64\shared\Microsoft.NETCore.App]

You can resolve the problem by installing the specified framework and/or SDK.

The specified framework can be found at:
  - https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=3.0.0&arch=x64&rid=win10-x64
```