### PR TITLE
Only encode first char

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -8,6 +8,7 @@ env:
   GprToolCsprojPath: src/GprTool/GprTool.csproj
   config: Release
   branch: action
+  ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
 jobs:
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,6 +7,7 @@ jobs:
 
     env:
       BUILT_IMAGE_NAME: gpr
+      ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -6,6 +6,7 @@ env:
   NBGV_VERSION: 3.1.91
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1 
+  ACTIONS_ALLOW_UNSECURE_COMMANDS: true # for nbgv
   
   GprToolCsprojPath: src/GprTool/GprTool.csproj
   GprToolTestsCsprojPath: test/GprTool.Tests/GprTool.Tests.csproj

--- a/src/GprTool/Program.cs
+++ b/src/GprTool/Program.cs
@@ -746,12 +746,12 @@ namespace GprTool
 
         static string XmlEncode(string str)
         {
-            return string.Concat(str.ToCharArray().Select(ch => $"&#{(int)ch};"));
+            return $"&#{(int)str[0]};" + str.Substring(1);
         }
 
         static string UnicodeEncode(string str)
         {
-            return string.Concat(str.ToCharArray().Select(ch => $"\\u{((int)ch).ToString("x4")}"));
+            return $"\\u{((int)str[0]).ToString("x4")}" + str.Substring(1);
         }
 
         [Argument(0, Description = "Personal Access Token")]


### PR DESCRIPTION
When obfuscating a PAT, only encode the first char to avoid verbose strings.