### PR TITLE
Use ${{ github.token }} for ghcr.io

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,7 +41,7 @@ jobs:
         IMAGE_NAME: docker.pkg.github.com/jcansdale/gpr/gpr:latest
 
     - name: Login to ghcr.io
-      run: docker login https://ghcr.io -u token --password-stdin <<< ${{ secrets.GHCR_TOKEN }}
+      run: docker login https://ghcr.io -u token --password-stdin <<< ${{ github.token }}
 
     - name: Publish to ghcr.io
       run: |


### PR DESCRIPTION
Use default GitHub Actions workflow token when pushing to ghcr.io.