### PR TITLE
Support using private instance repo URL in upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,5 +26,3 @@ Commands:
 
 Run 'gpr [command] --help' for more information about a command.
 ```
-
-:bulb: By default https://nuget.pkg.github.com is used as the endpoint. You can overwrite it by setting `BASE_URL` environment variable to a private instance.

--- a/README.md
+++ b/README.md
@@ -26,3 +26,5 @@ Commands:
 
 Run 'gpr [command] --help' for more information about a command.
 ```
+
+:bulb: By default https://nuget.pkg.github.com is used as the endpoint. You can overwrite it by setting `BASE_URL` environment variable to a private instance.

--- a/src/GprTool/NuGetUtilities.cs
+++ b/src/GprTool/NuGetUtilities.cs
@@ -36,10 +36,9 @@ namespace GprTool
 
             repositoryUrl = repositoryUrl.Trim();
 
-            Uri baseUri = GetBaseUri();
             if (Uri.IsWellFormedUriString(repositoryUrl, UriKind.Relative))
             {
-                repositoryUrl = $"{baseUri}/{repositoryUrl}";
+                repositoryUrl = $"https://github.com/{repositoryUrl}";
             }
 
             if (!Uri.TryCreate(repositoryUrl, UriKind.Absolute, out var repositoryUri) 

--- a/src/GprTool/Program.cs
+++ b/src/GprTool/Program.cs
@@ -618,8 +618,7 @@ namespace GprTool
         {
             var user = "GprTool";
             var token = GetAccessToken();
-            var baseUri = NuGetUtilities.GetBaseUri();
-            var client = WithRestClient($"{baseUri}/{Owner}/{Name}/{Version}.json");
+            var client = WithRestClient($"https://nuget.pkg.github.com/{Owner}/{Name}/{Version}.json");
             client.Authenticator = new HttpBasicAuthenticator(user, token);
             var request = new RestRequest(Method.GET);
             var response = await client.ExecuteAsync<IRestResponse>(request, cancellationToken: cancellationToken);

--- a/src/GprTool/Program.cs
+++ b/src/GprTool/Program.cs
@@ -538,7 +538,8 @@ namespace GprTool
                 if (packageFile == null) throw new ArgumentNullException(nameof(packageFile));
                 if (packageStream == null) throw new ArgumentNullException(nameof(packageStream));
 
-                var client = WithRestClient($"https://nuget.pkg.github.com/{packageFile.Owner}/",
+                var baseUri = NuGetUtilities.GetBaseUri();
+                var client = WithRestClient($"{baseUri}/{packageFile.Owner}/",
                     x =>
                     {
                         x.Authenticator = new HttpBasicAuthenticator(user, token);
@@ -618,7 +619,8 @@ namespace GprTool
         {
             var user = "GprTool";
             var token = GetAccessToken();
-            var client = WithRestClient($"https://nuget.pkg.github.com/{Owner}/{Name}/{Version}.json");
+            var baseUri = NuGetUtilities.GetBaseUri();
+            var client = WithRestClient($"{baseUri}/{Owner}/{Name}/{Version}.json");
             client.Authenticator = new HttpBasicAuthenticator(user, token);
             var request = new RestRequest(Method.GET);
             var response = await client.ExecuteAsync<IRestResponse>(request, cancellationToken: cancellationToken);

--- a/src/GprTool/Program.cs
+++ b/src/GprTool/Program.cs
@@ -538,8 +538,7 @@ namespace GprTool
                 if (packageFile == null) throw new ArgumentNullException(nameof(packageFile));
                 if (packageStream == null) throw new ArgumentNullException(nameof(packageStream));
 
-                var baseUri = NuGetUtilities.GetBaseUri();
-                var client = WithRestClient($"{baseUri}/{packageFile.Owner}/",
+                var client = WithRestClient($"https://{packageFile.NugetPackageEndpoint}/{packageFile.Owner}/",
                     x =>
                     {
                         x.Authenticator = new HttpBasicAuthenticator(user, token);

--- a/test/GprTool.Tests/NuGetUtilitiesTests.cs
+++ b/test/GprTool.Tests/NuGetUtilitiesTests.cs
@@ -212,6 +212,27 @@ namespace GprTool.Tests
                 Assert.That(packageFile.RepositoryUrl, Is.EqualTo(expectedGithubRepositoryUrl));
             }
 
+            [TestCase("ritchxu/gpr", true, "ritchxu", "gpr", "https://github.com/ritchxu/gpr", "nuget.pkg.github.com")]
+            [TestCase("https://foo.githubenterprise.com/ritchxu/gpr", true, "ritchxu", "gpr", "https://foo.githubenterprise.com/ritchxu/gpr", "nuget.foo.githubenterprise.com")]
+            [TestCase("https://foo.bar.com/ritchxu/gpr", false, null, null, null, null)]
+            public void BuildOwnerAndRepositoryFromUrl(
+                string repositoryUrl,
+                bool expectedResult,
+                string expectedOwner,
+                string expectedRepositoryName,
+                string expectedGithubRepositoryUrl,
+                string expectedNugetPackageEndpoint)
+            {
+                var packageFile = new PackageFile();
+
+                Assert.That(NuGetUtilities.BuildOwnerAndRepositoryFromUrl(packageFile, repositoryUrl), Is.EqualTo(expectedResult));
+
+                Assert.That(packageFile.Owner, Is.EqualTo(expectedOwner));
+                Assert.That(packageFile.RepositoryName, Is.EqualTo(expectedRepositoryName));
+                Assert.That(packageFile.RepositoryUrl, Is.EqualTo(expectedGithubRepositoryUrl));
+                Assert.That(packageFile.NugetPackageEndpoint, Is.EqualTo(expectedNugetPackageEndpoint));
+            }
+
             [Test]
             public void ReadNupkgManifest()
             {


### PR DESCRIPTION
This PR makes it possible to use a private instance's repo URL when pushing packages.