### PR TITLE
Support pusing NuGet packages to GHES with subdomain isolation

### DIFF
--- a/src/GprTool/NuGetUtilities.cs
+++ b/src/GprTool/NuGetUtilities.cs
@@ -27,7 +27,7 @@ namespace GprTool
 
     public class NuGetUtilities
     {
-        public static bool BuildOwnerAndRepositoryFromUrl(PackageFile packageFile, string repositoryUrl)
+        public static bool BuildOwnerAndRepositoryFromUrl(PackageFile packageFile, string repositoryUrl, bool subdomainIsolation)
         {
             if (repositoryUrl == null)
             {
@@ -69,26 +69,27 @@ namespace GprTool
             packageFile.Owner = ownerAndRepositoryName[0];
             packageFile.RepositoryName = ownerAndRepositoryName[1];
             packageFile.RepositoryUrl = $"https://{repositoryUri.Host}/{packageFile.Owner}/{packageFile.RepositoryName}";
+
             if (repositoryUri.Host != "github.com")
             {
-                packageFile.NugetPackageEndpoint = $"nuget.{repositoryUri.Host}";
+                packageFile.NugetPackageEndpoint = subdomainIsolation ? $"nuget.{repositoryUri.Host}" : $"{repositoryUri.Host}/_registry/nuget";
             }
             else
             {
                 packageFile.NugetPackageEndpoint = $"nuget.pkg.github.com";
             }
-
+            
             return true;
         }
 
-        public static bool BuildOwnerAndRepositoryFromUrlFromNupkg(PackageFile packageFile)
+        public static bool BuildOwnerAndRepositoryFromUrlFromNupkg(PackageFile packageFile, bool subdomainIsolation = true)
         {
             var manifest = ReadNupkgManifest(packageFile.FilenameAbsolutePath);
             
-            return BuildOwnerAndRepositoryFromUrl(packageFile, manifest.Metadata.Repository?.Url);
+            return BuildOwnerAndRepositoryFromUrl(packageFile, manifest.Metadata.Repository?.Url, subdomainIsolation);
         }
 
-        public static PackageFile BuildPackageFile(string filename, string repositoryUrl)
+        public static PackageFile BuildPackageFile(string filename, string repositoryUrl, bool subdomainIsolation = true)
         {
             var packageFile = new PackageFile
             {
@@ -96,7 +97,7 @@ namespace GprTool
                 FilenameAbsolutePath = Path.GetFullPath(filename)
             };
 
-            BuildOwnerAndRepositoryFromUrl(packageFile, repositoryUrl);
+            BuildOwnerAndRepositoryFromUrl(packageFile, repositoryUrl, subdomainIsolation);
 
             return packageFile;
         }

--- a/src/GprTool/Program.cs
+++ b/src/GprTool/Program.cs
@@ -442,7 +442,7 @@ namespace GprTool
             packageFiles.AddRange(
                 currentDirectory
                     .GetFilesByGlobPatterns(GlobPatterns, out var glob)
-                    .Select(x => NuGetUtilities.BuildPackageFile(x, RepositoryUrl)));
+                    .Select(x => NuGetUtilities.BuildPackageFile(x, RepositoryUrl, SubdomainIsolation)));
 
             if (!packageFiles.Any())
             {
@@ -462,7 +462,7 @@ namespace GprTool
 
                 if (RepositoryUrl == null)
                 {
-                    if (!NuGetUtilities.BuildOwnerAndRepositoryFromUrlFromNupkg(packageFile))
+                    if (!NuGetUtilities.BuildOwnerAndRepositoryFromUrlFromNupkg(packageFile, SubdomainIsolation))
                     {
                         Console.WriteLine("Could not build owner and repository for provided package");
                         return 1;
@@ -471,7 +471,7 @@ namespace GprTool
                 else
                 {
 
-                    if (!NuGetUtilities.BuildOwnerAndRepositoryFromUrl(packageFile, RepositoryUrl))
+                    if (!NuGetUtilities.BuildOwnerAndRepositoryFromUrl(packageFile, RepositoryUrl, SubdomainIsolation))
                     {
                         Console.WriteLine("Could not build owner and repository for provided package and repository url");
                         return 1;
@@ -618,6 +618,9 @@ namespace GprTool
 
         [Option("--retries", Description = "The number of retries in case of intermittent connection issue. Default value is 3. Set to 0 if you want to disable automatic retry.")]
         public int Retries { get; set; } = 3;
+
+        [Option("--subdomain-isolation", Description = "Subdomain isolation for GitHub Enterprise Server appliance. Default value is true.")]
+        public bool SubdomainIsolation { get; set; } = true;
     }
 
     [Command(Description = "View package details")]

--- a/test/GprTool.Tests/NuGetUtilitiesTests.cs
+++ b/test/GprTool.Tests/NuGetUtilitiesTests.cs
@@ -201,7 +201,7 @@ namespace GprTool.Tests
                         Type = "git"
                     };
                 }));
-
+                
                 packageBuilderContext.Build();
 
                 var packageFile = NuGetUtilities.BuildPackageFile(packageBuilderContext.NupkgFilename, null);
@@ -213,11 +213,13 @@ namespace GprTool.Tests
                 Assert.That(packageFile.RepositoryUrl, Is.EqualTo(expectedGithubRepositoryUrl));
             }
 
-            [TestCase("ritchxu/gpr", true, "ritchxu", "gpr", "https://github.com/ritchxu/gpr", "nuget.pkg.github.com")]
-            [TestCase("https://foo.githubenterprise.com/ritchxu/gpr", true, "ritchxu", "gpr", "https://foo.githubenterprise.com/ritchxu/gpr", "nuget.foo.githubenterprise.com")]
-            [TestCase("https://foo.bar.com/ritchxu/gpr", true, "ritchxu", "gpr", "https://foo.bar.com/ritchxu/gpr", "nuget.foo.bar.com")]
+            [TestCase("ritchxu/gpr", true, true, "ritchxu", "gpr", "https://github.com/ritchxu/gpr", "nuget.pkg.github.com")]
+            [TestCase("https://foo.githubenterprise.com/ritchxu/gpr", true, true, "ritchxu", "gpr", "https://foo.githubenterprise.com/ritchxu/gpr", "nuget.foo.githubenterprise.com")]
+            [TestCase("https://foo.bar.com/ritchxu/gpr", true, true, "ritchxu", "gpr", "https://foo.bar.com/ritchxu/gpr", "nuget.foo.bar.com")]
+            [TestCase("https://foo.bar.com/ritchxu/gpr", false, true, "ritchxu", "gpr", "https://foo.bar.com/ritchxu/gpr", "foo.bar.com/_registry/nuget")]
             public void BuildOwnerAndRepositoryFromUrl(
                 string repositoryUrl,
+                bool subdomainIsolation,
                 bool expectedResult,
                 string expectedOwner,
                 string expectedRepositoryName,
@@ -226,7 +228,7 @@ namespace GprTool.Tests
             {
                 var packageFile = new PackageFile();
 
-                Assert.That(NuGetUtilities.BuildOwnerAndRepositoryFromUrl(packageFile, repositoryUrl), Is.EqualTo(expectedResult));
+                Assert.That(NuGetUtilities.BuildOwnerAndRepositoryFromUrl(packageFile, repositoryUrl, subdomainIsolation), Is.EqualTo(expectedResult));
 
                 Assert.That(packageFile.Owner, Is.EqualTo(expectedOwner));
                 Assert.That(packageFile.RepositoryName, Is.EqualTo(expectedRepositoryName));


### PR DESCRIPTION
For example.

```
gpr push foo.nuget --subdomain-isolation=true
```

Fixes #119