### PR TITLE
Set `RollForward=Major` instead of `LatestMajor`.

### DIFF
--- a/src/GprTool/GprTool.csproj
+++ b/src/GprTool/GprTool.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-    <RollForward>LatestMajor</RollForward>
+    <RollForward>Major</RollForward>
     <Authors>Jamie Cansdale</Authors>
     <Company>Mutant Design Limited</Company>
     <Product>GprTool</Product>


### PR DESCRIPTION
In #99, I proposed `LatestMajor`. That is *usually* fine, but `Major` is preferable to make things more predictable; `Major` will prefer the runtime that the app was built for before rolling forward, while `LatestMajor` will always roll forward.